### PR TITLE
Fix typo on the README ("darwn" -> "drawn")

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # fourier-sketch
-An educational web-app that uses the fourier series to approximate user darwn sketches. 
+An educational web-app that uses the fourier series to approximate user drawn sketches. 


### PR DESCRIPTION
Didn't realize it was on the README as well before I tweeted @ you :)

Great work Srijan!